### PR TITLE
feat: Enabled file uploads, made blog post media optional

### DIFF
--- a/backend/src/components/sections/media-section.json
+++ b/backend/src/components/sections/media-section.json
@@ -10,12 +10,22 @@
     "title": {
       "type": "string"
     },
+    "layout": {
+      "type": "enumeration",
+      "enum": [
+        "left",
+        "right"
+      ],
+      "default": "right"
+    },
     "media": {
       "type": "media",
       "multiple": false,
       "required": false,
       "allowedTypes": [
-        "images"
+        "images",
+        "videos",
+        "files"
       ]
     },
     "description": {

--- a/backend/src/components/sections/media-section.json
+++ b/backend/src/components/sections/media-section.json
@@ -2,7 +2,8 @@
   "collectionName": "components_sections_media_sections",
   "info": {
     "displayName": "Media Section",
-    "icon": "equals"
+    "icon": "equals",
+    "description": ""
   },
   "options": {},
   "attributes": {
@@ -10,10 +11,12 @@
       "type": "string"
     },
     "media": {
-      "allowedTypes": ["images"],
       "type": "media",
       "multiple": false,
-      "required": true
+      "required": false,
+      "allowedTypes": [
+        "images"
+      ]
     },
     "description": {
       "type": "richtext",

--- a/frontend/src/components/AppMediaSection.vue
+++ b/frontend/src/components/AppMediaSection.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import { IMedia } from '../types/strapi'
 import { markdownToHtml } from '../utils/strings'
+import BButton from './bootstrap/BButton.vue'
 
 interface MediaSectionProps {
   title?: string
@@ -26,14 +27,25 @@ const mediaType = computed((): string => props.media.data?.attributes.mime.split
           :class="{
             'pl-lg-5': layout === 'left',
             'pr-lg-5': layout === 'right',
-            'col-lg-6': media.data,
+            'col-lg-6': media.data && mediaType !== 'application',
           }"
         >
           <h2 v-if="title">{{ title }}</h2>
           <div v-html="markdownToHtml(description)"></div>
+
+          <BButton
+            v-if="media.data && mediaType === 'application'"
+            class="mt-4"
+            :href="media.data.attributes.url"
+          >
+            Datei herunterladen
+          </BButton>
         </div>
 
-        <div v-if="media.data" class="col-lg-6 justify-content-lg-center d-flex mt-4 mt-lg-0">
+        <div
+          v-if="media.data && mediaType !== 'application'"
+          class="col-lg-6 justify-content-lg-center d-flex mt-4 mt-lg-0"
+        >
           <img
             v-if="mediaType === 'image'"
             :src="media.data.attributes.url"

--- a/frontend/src/components/AppMediaSection.vue
+++ b/frontend/src/components/AppMediaSection.vue
@@ -23,10 +23,10 @@ const mediaType = computed((): string => props.media.data?.attributes.mime.split
     <div class="container">
       <div class="row align-items-center" :class="{ 'flex-row-reverse': layout === 'left' }">
         <div
-          class="col-lg-6"
           :class="{
             'pl-lg-5': layout === 'left',
             'pr-lg-5': layout === 'right',
+            'col-lg-6': media.data,
           }"
         >
           <h2 v-if="title">{{ title }}</h2>

--- a/frontend/src/views/BlogPost.vue
+++ b/frontend/src/views/BlogPost.vue
@@ -56,7 +56,7 @@ if (blogId !== -1) blogStore.fetchPost(blogId)
 
         <div
           v-else-if="post"
-          class="text-center"
+          class="mt-4"
           v-html="markdownToHtml(post ? post.attributes.description : '')"
         ></div>
       </div>


### PR DESCRIPTION
- In blog post: Media in media section is now optional
- Files can now be uploaded in addition to images and videos
- Readded missing "layout" setting for media section
- fix: Blog post top description is not left-aligned to fix display error when e.g. lists are used
- closes #26 